### PR TITLE
Misc cleanups

### DIFF
--- a/tests/examples/digital_fingerprinting/test_dfp_preprocessing_stage.py
+++ b/tests/examples/digital_fingerprinting/test_dfp_preprocessing_stage.py
@@ -61,4 +61,4 @@ def test_process_features(
     results = stage.process_features(dfp_multi_message)
 
     assert isinstance(results, MultiDFPMessage)
-    dataset_pandas.assert_df_equal(results.get_meta_dataframe(), expected_df)
+    dataset_pandas.assert_compare_df(results.get_meta_dataframe(), expected_df)

--- a/tests/utils/nvt/test_transforms.py
+++ b/tests/utils/nvt/test_transforms.py
@@ -16,9 +16,8 @@ import pandas as pd
 import pytest
 from nvtabular.ops.operator import ColumnSelector
 
-import cudf
-
 from morpheus.utils.nvt.transforms import json_flatten
+from morpheus.utils.type_aliases import DataFrameType
 from utils.dataset_manager import DatasetManager
 
 
@@ -37,7 +36,7 @@ def df_fixture(dataset: DatasetManager, data: dict):
     yield dataset.df_class(data)
 
 
-def test_json_flatten(df: pd.DataFrame):
+def test_json_flatten(df: DataFrameType):
     col_selector = ColumnSelector(["info"])
     result = json_flatten(col_selector, df)
 


### PR DESCRIPTION
* Cleanup imports and type-hints in `tests/utils/nvt/test_transforms.py`
* Use compare method in `tests/examples/digital_fingerprinting/test_dfp_preprocessing_stage.py`